### PR TITLE
skip tagging type if value is nil

### DIFF
--- a/caching_tag.go
+++ b/caching_tag.go
@@ -118,7 +118,9 @@ func (c *cachingTagVisitor) collectTypeKeyTags(path []string, data interface{}, 
 			c.collectTypeKeyTags(path, item, typeName)
 		}
 	case map[string]interface{}:
-		c.addTagForTypeKey(at, v[at], typeName)
+		if v[at] != nil {
+			c.addTagForTypeKey(at, v[at], typeName)
+		}
 	default:
 		c.Walker.StopWithInternalErr(fmt.Errorf("invalid data type expected map or array map but got %T", v))
 	}

--- a/caching_tag.go
+++ b/caching_tag.go
@@ -122,7 +122,9 @@ func (c *cachingTagVisitor) collectTypeKeyTags(path []string, data interface{}, 
 			c.addTagForTypeKey(at, v[at], typeName)
 		}
 	default:
-		c.Walker.StopWithInternalErr(fmt.Errorf("invalid data type expected map or array map but got %T", v))
+		if v != nil {
+			c.Walker.StopWithInternalErr(fmt.Errorf("invalid data type expected map or array map but got %T", v))
+		}
 	}
 }
 


### PR DESCRIPTION
There are cases when the response may not contain all the types as requested. For instances in cases a query uses union, some types may be resolved while some will be nil. Hence skipping tagging in case the value of field is nil.